### PR TITLE
Reconcile event handlers in yo.update

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,25 +1,27 @@
 var yo = require('yo-yo')
 
+var count = 5
 var numbers = [] // start empty
-var el = list(numbers, update)
+var el = list(numbers, function() { update(0) })
 
 function list (items, onclick) {
-  return yo`<div>Random Numbers
+  return yo`<div>Countdown
     <ul>
       ${items.map(function (item) {
         return yo`<li>${item}</li>`
       })}
     </ul>
-    <button onclick=${onclick}>Add Random Number</button>
+    <button onclick=${count > 0 ? onclick : null}>Subtract Random Number</button>
   </div>`
 }
 
-function update () {
-  // add a new random number to our list
-  numbers.push(Math.random())
+function update (n) {
+  // subtract n from our count
+  count -= n
+  numbers.push(count)
   
   // construct a new list and efficiently diff+morph it into the one in the DOM
-  var newList = list(numbers, update)
+  var newList = list(numbers, function() { update(Math.random()) })
   yo.update(el, newList)
 }
 

--- a/index.js
+++ b/index.js
@@ -1,2 +1,41 @@
-module.exports = require('bel') // turns template tag into DOM elements
-module.exports.update = require('morphdom') // efficiently diffs + morphs two DOM elements
+var hyperx = require('hyperx')
+var bel = require('bel')
+var morphdom = require('morphdom')
+
+// turns template tag into DOM elements
+module.exports = hyperx(function yo (tag, props, children) {
+  var el = bel(tag, props, children)
+
+  // store event handlers for diff step
+  el._handlers = {}
+  for (var name in props) {
+    if (props.hasOwnProperty(name) && name.slice(0, 2) === 'on') {
+      el._handlers[name] = props[name]
+    }
+  }
+
+  return el
+})
+
+function onBeforeMorphEl (fromEl, toEl) {
+  // update element with new event handlers
+  for (var name in toEl._handlers) {
+    if (toEl._handlers.hasOwnProperty(name)) {
+      fromEl[name] = toEl._handlers[name]
+    }
+  }
+
+  // clean up removed event handlers
+  if (fromEl._handlers) {
+    for (var name in fromEl._handlers) {
+      if (!toEl._handlers.hasOwnProperty(name)) {
+        delete fromEl[name]
+      }
+    }
+  }
+}
+
+// efficiently diffs + morphs two DOM elements
+module.exports.update = function (fromEl, toEl) {
+  morphdom(fromEl, toEl, { onBeforeMorphEl: onBeforeMorphEl })
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "homepage": "https://github.com/maxogden/yo-yo#readme",
   "dependencies": {
-    "bel": "^4.0.0",
+    "hyperx": "^2.0.2",
+    "bel": "shama/bel#yo-yo",
     "morphdom": "^1.1.2"
   }
 }


### PR DESCRIPTION
Currently, event handlers (`onclick`, etc) are not updated by `yo.update`. I've updated `example.js` with a contrived demo of this.

Here's an approach to add event handlers diffing to yo inspired by this [twitter thread](https://twitter.com/chromakode/status/708478531567636480). When `yo` template literals are evaluated, the event handler properties for tags are saved as a `_handlers` expando property of the node `bel` generates. Then in `yo.update`, when we morph a node into another one, we compare their `_handlers` mappings and add/remove the changes.

Unfortunately I had to downgrade `bel` to access its inner function without being wrapped by `hyperx`. I couldn't find another way to get at it. @shama, would you consider exposing the `bel` function as a property of the default export?
