### PR TITLE
Update bel dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/maxogden/yo-yo#readme",
   "dependencies": {
-    "bel": "^4.0.0",
+    "bel": "^4.4.1",
     "morphdom": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Incorporates shama/bel#32. Technically the `^` makes this not necessary, but @yoshuawuyts suggested that:

> cached builds might not catch it so it's recommended to do it anyway

I didn't bump the `yo-yo` version because I imagine you may have a process for doing that and publishing to npm, but let me know if I should amend the commit to do that.

Is it worth also mentioning this new feature in the `README`? Feels like we could copy & paste the section from `bel` though I'm not sure the history with `yo-yo` and `bel` (feels like much of the docs could be copied & pasted) so I won't presume.
