### PR TITLE
Make rollupjs work

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var defaultEvents = require('./update-events.js') // default events to be copied
 module.exports = bel
 
 // TODO move this + defaultEvents to a new module once we receive more feedback
-module.exports.update = function (fromNode, toNode, opts) {
+bel.update = function (fromNode, toNode, opts) {
   if (!opts) opts = {}
   if (opts.events !== false) {
     if (!opts.onBeforeMorphEl) opts.onBeforeMorphEl = copier


### PR DESCRIPTION
Rollup.js seems to break when setting and then modifying an export like this. Modifying `bel` directly fixes the issue.
