### PR TITLE
do not copy form values if value attribute is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,9 +28,10 @@ module.exports.update = function (fromNode, toNode, opts) {
     }
     var oldValue = f.value
     var newValue = t.value
+    var handlesChange = (f.oninput && t.oninput) || (f.onchange && t.onchange)
     // copy values for form elements
     if ((f.nodeName === 'INPUT' && f.type !== 'file') || f.nodeName === 'SELECT') {
-      if (!newValue) {
+      if (!newValue && !handlesChange) {
         t.value = f.value
       } else if (newValue !== oldValue) {
         f.value = newValue

--- a/index.js
+++ b/index.js
@@ -28,10 +28,9 @@ module.exports.update = function (fromNode, toNode, opts) {
     }
     var oldValue = f.value
     var newValue = t.value
-    var handlesChange = t.oninput || t.onchange
     // copy values for form elements
     if ((f.nodeName === 'INPUT' && f.type !== 'file') || f.nodeName === 'SELECT') {
-      if (!newValue && !handlesChange) {
+      if (!newValue && !t.hasAttribute('value')) {
         t.value = f.value
       } else if (newValue !== oldValue) {
         f.value = newValue

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports.update = function (fromNode, toNode, opts) {
     }
     var oldValue = f.value
     var newValue = t.value
-    var handlesChange = (f.oninput && t.oninput) || (f.onchange && t.onchange)
+    var handlesChange = t.oninput || t.onchange
     // copy values for form elements
     if ((f.nodeName === 'INPUT' && f.type !== 'file') || f.nodeName === 'SELECT') {
       if (!newValue && !handlesChange) {

--- a/test.js
+++ b/test.js
@@ -58,10 +58,9 @@ test('input value gets updated', function (t) {
 
 test('input value can be update to empty string', function (t) {
   t.plan(1)
-  var el = yo`<input type="text" oninput=${Function.prototype}/>`
+  var el = yo`<input type="text"/>`
   el.value = 'hola'
-  var newEl = yo`<input type="text" oninput=${Function.prototype}/>`
-  newEl.value = ''
+  var newEl = yo`<input type="text" value=""/>`
   yo.update(el, newEl)
   t.equal(el.value, '')
 })

--- a/test.js
+++ b/test.js
@@ -56,6 +56,16 @@ test('input value gets updated', function (t) {
     t.equal(el.value, 'hi')
 })
 
+test('input value can be update to empty string', function (t) {
+  t.plan(1)
+  var el = yo`<input type="text" oninput=${Function.prototype}/>`
+  el.value = 'hola'
+  var newEl = yo`<input type="text" oninput=${Function.prototype}/>`
+  newEl.value = ''
+  yo.update(el, newEl)
+  t.equal(el.value, '')
+})
+
 test('textarea values get copied', function (t) {
   t.plan(1)
   function textarea (val) {


### PR DESCRIPTION
*Updated based on some discussion in [this issue](https://github.com/maxogden/yo-yo/issues/66)

Because an input that looks like this `<input type='text'/>` will still have a `value` of `""`, the `el.value` method can't be used to distinguish between how it should update different than something like `<input type='text' value="" />` 

Use case:

Between updates:
`<input type='text' />` = will copy over the value, because `hasAttribute('value')` will return false even after user input   

`<input type='text' value=${val} />` will set the value to whatever `val` is, even if it is an empty string, because `hasAttribute('value')` will return true

This relates to the issue here:
https://github.com/maxogden/yo-yo/issues/66
